### PR TITLE
Make falling block trajectories more realistic

### DIFF
--- a/src/com/kixmc/PE/core/Visuals.java
+++ b/src/com/kixmc/PE/core/Visuals.java
@@ -12,24 +12,38 @@ import java.util.List;
 public class Visuals {
 
     // the core visual
-    public static void createRealisticExplosion(List<Block> list) {
+    public static void createRealisticExplosion(Location sourcePoint, List<Block> list) {
 
         for (Block b : list) {
             if (PrettierExplosions.get().activeBlocksCount >= PrettierExplosions.get().visualCap) break;
-
-            FallingBlock fb;
 
             // don't include these blocks in the visual (more importantly the active blocks count)
             if (b.getType() == Material.AIR) continue;
             if (b.getType() == Material.CAVE_AIR) continue; // not sure if this is necessary
             if (b.getType() == Material.TNT) continue;
+            if (!b.getType().isSolid()) continue; // only launch solid blocks
 
             // create the entity
-            fb = b.getWorld().spawnFallingBlock(b.getLocation().add(0, 1, 0), b.getBlockData());
+            FallingBlock fb = b.getWorld().spawnFallingBlock(b.getLocation().add(0.5, 0.5, 0.5), b.getBlockData());
             fb.setDropItem(false);
 
-            // give it random velocity within limit
-            fb.setVelocity(new Vector((float) -1 + (float) (Math.random() * ((1 - -1) + 1)), (float) 0.5, (float) -0.3 + (float) (Math.random() * ((0.3 - -0.3) + 1))));
+            // fling the blocks away from the explosion source point
+            double distance = fb.getLocation().distance(sourcePoint);
+            Vector velocity = fb.getLocation().clone().subtract(sourcePoint).toVector().normalize().divide(new Vector(distance, distance, distance)).multiply(1.5);
+
+            // always make sure the blocks get thrown into the air
+            if (velocity.getY() < 0) {
+                velocity.multiply(new Vector(1, -1.5, 1));
+            } else {
+                velocity.multiply(new Vector(1, 1.5, 1));
+            }
+
+            // don't let the blocks fly *too* high
+            if (velocity.getY() > 2) velocity.setY(2);
+
+            // add a little bit of randomness
+            velocity.add(Vector.getRandom().multiply(0.05));
+            fb.setVelocity(velocity);
 
             // save it to flying blocks list so we can delete it when it lands instead of it placing as an actual block
             PrettierExplosions.get().flyingBlocks.add(fb);
@@ -40,10 +54,9 @@ public class Visuals {
     }
 
     // currently the only extra visual
-    public static void createBlockLandEffect(Location l, Block b) {
+    public static void createBlockLandEffect(FallingBlock fb) {
         // makes block break looking particles of the inputted blocks material
-        l.getWorld().playEffect(l, Effect.STEP_SOUND,
-                b.getLocation().subtract(0, 1, 0).getBlock().getType());
+        fb.getWorld().playEffect(fb.getLocation(), Effect.STEP_SOUND, fb.getBlockData().getMaterial());
     }
 
 }

--- a/src/com/kixmc/PE/listeners/BlockExplode.java
+++ b/src/com/kixmc/PE/listeners/BlockExplode.java
@@ -25,7 +25,7 @@ public class BlockExplode implements Listener {
         if (PrettierExplosions.get().executeOnBeds && isBed) shouldFly = true;
         if (PrettierExplosions.get().executeOnOther && !isBed) shouldFly = true;
 
-        if (shouldFly) Visuals.createRealisticExplosion(e.blockList());
+        if (shouldFly) Visuals.createRealisticExplosion(e.getBlock().getLocation(), e.blockList());
 
     }
 

--- a/src/com/kixmc/PE/listeners/EntityChangeBlock.java
+++ b/src/com/kixmc/PE/listeners/EntityChangeBlock.java
@@ -17,7 +17,8 @@ public class EntityChangeBlock implements Listener {
     public void deleteFlyingBlocksOnLand(EntityChangeBlockEvent e) {
 
         if (!(e.getEntity() instanceof FallingBlock)) return;
-        if (!PrettierExplosions.get().flyingBlocks.contains((FallingBlock) e.getEntity())) return;
+        FallingBlock fb = (FallingBlock) e.getEntity();
+        if (!PrettierExplosions.get().flyingBlocks.contains(fb)) return;
 
         e.setCancelled(true);
 
@@ -25,7 +26,7 @@ public class EntityChangeBlock implements Listener {
 
         if (PrettierExplosions.get().extraVisuals) {
             // give the block landing particles so it doesn't just vanish into thin air
-            Visuals.createBlockLandEffect(e.getEntity().getLocation(), e.getBlock());
+            Visuals.createBlockLandEffect(fb);
         }
 
     }

--- a/src/com/kixmc/PE/listeners/EntityExplode.java
+++ b/src/com/kixmc/PE/listeners/EntityExplode.java
@@ -25,7 +25,7 @@ public class EntityExplode implements Listener {
         if (PrettierExplosions.get().executeOnCreepers && e.getEntityType() == EntityType.CREEPER) shouldFly = true;
         if (PrettierExplosions.get().executeOnOther && e.getEntityType() != EntityType.PRIMED_TNT) shouldFly = true;
 
-        if (shouldFly) Visuals.createRealisticExplosion(e.blockList());
+        if (shouldFly) Visuals.createRealisticExplosion(e.getLocation(), e.blockList());
 
     }
 


### PR DESCRIPTION
The falling block trajectories were entirely random before, now they are launched away from the source point of the explosion.
Example: https://gyazo.com/5165f8caf2445eee0889d8c646ef5f7f

I also want to point out that while this plugin claims it supports 1.8 to 1.16, it only actually supports 1.13 and newer due to the use of BlockData and materials such as CAVE_AIR. 