### PR TITLE
Update to 1.21, separate settings for windcharges

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.13-R0.1-SNAPSHOT</version>
+            <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.kixmc</groupId>
     <artifactId>KixsPrettierExplosions</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
 
     <repositories>
         <repository>

--- a/src/com/kixmc/PE/config/ConfigVarLoader.java
+++ b/src/com/kixmc/PE/config/ConfigVarLoader.java
@@ -10,6 +10,7 @@ public class ConfigVarLoader {
         PrettierExplosions.get().executeOnBeds = PrettierExplosions.get().getConfig().getBoolean("prettify.bed-explosions");
         PrettierExplosions.get().executeOnCreepers = PrettierExplosions.get().getConfig().getBoolean("prettify.creeper-explosions");
         PrettierExplosions.get().executeOnOther = PrettierExplosions.get().getConfig().getBoolean("prettify.other-explosions");
+        PrettierExplosions.get().executeOnWindCharge = PrettierExplosions.get().getConfig().getBoolean("prettify.windcharge-explosions");
 
         PrettierExplosions.get().extraVisuals = PrettierExplosions.get().getConfig().getBoolean("extra-visuals");
 

--- a/src/com/kixmc/PE/core/PrettierExplosions.java
+++ b/src/com/kixmc/PE/core/PrettierExplosions.java
@@ -35,6 +35,7 @@ public class PrettierExplosions extends JavaPlugin implements Listener, CommandE
     public boolean executeOnBeds = false;
     public boolean executeOnCreepers = false;
     public boolean executeOnOther = false;
+    public boolean executeOnWindCharge = false;
 
     public boolean extraVisuals = true;
     public boolean realisticTrajectories = true;

--- a/src/com/kixmc/PE/listeners/EntityExplode.java
+++ b/src/com/kixmc/PE/listeners/EntityExplode.java
@@ -21,9 +21,21 @@ public class EntityExplode implements Listener {
 
         boolean shouldFly = false;
 
-        if (PrettierExplosions.get().executeOnTnt && e.getEntityType() == EntityType.PRIMED_TNT) shouldFly = true;
-        if (PrettierExplosions.get().executeOnCreepers && e.getEntityType() == EntityType.CREEPER) shouldFly = true;
-        if (PrettierExplosions.get().executeOnOther && e.getEntityType() != EntityType.PRIMED_TNT) shouldFly = true;
+        switch(e.getEntityType()) {
+            case TNT_MINECART:
+            case TNT:
+                shouldFly = PrettierExplosions.get().executeOnTnt;
+                break;
+            case CREEPER:
+                shouldFly = PrettierExplosions.get().executeOnCreepers;
+                break;
+            case WIND_CHARGE:
+                shouldFly = PrettierExplosions.get().executeOnWindCharge;
+                break;
+            default:
+                shouldFly = PrettierExplosions.get().executeOnOther;
+                break;
+        }
 
         if (shouldFly) Visuals.createRealisticExplosion(e.getLocation(), e.blockList());
 

--- a/src/config.yml
+++ b/src/config.yml
@@ -13,6 +13,7 @@ prettify:
   tnt-explosions: true
   bed-explosions: true
   creeper-explosions: true
+  windcharge-explosions: false
   other-explosions: true
 
 extra-visuals: true

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -3,7 +3,7 @@ description: Stunning realistic tnt & explosion visuals. Respects fps, protectio
 author: kixmc
 version: 1.0.1
 main: com.kixmc.PE.core.PrettierExplosions
-api-version: 1.13
+api-version: 1.21
 commands:
   prettierexplosions:
     aliases: [pe]


### PR DESCRIPTION
Changes API dependency to 1.21.

Adds a separate config option to toggle off windcharges spawning pretty explosions